### PR TITLE
Upgrade GitHub Actions to latest versions for checkout, cache, and se…

### DIFF
--- a/.github/workflows/new_deploy_branch_dev.yml
+++ b/.github/workflows/new_deploy_branch_dev.yml
@@ -19,11 +19,11 @@ jobs:
         run: echo ${{github.ref}}
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -44,9 +44,10 @@ jobs:
         run: echo ${{ inputs.NODE_VERSION }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.NODE_VERSION }}
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/new_deploy_branch_prd.yml
+++ b/.github/workflows/new_deploy_branch_prd.yml
@@ -16,11 +16,11 @@ jobs:
       AWS_REGION: "us-east-1"
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -36,9 +36,10 @@ jobs:
         run: echo ${{ inputs.NODE_VERSION }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.NODE_VERSION }}
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install
@@ -88,7 +89,7 @@ jobs:
         run: node -p -e '`PACKAGE_VERSION=${require("./package.json").version}`' >> $GITHUB_ENV
       - name: Create release
         # https://github.com/actions/create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/new_deploy_branch_uat.yml
+++ b/.github/workflows/new_deploy_branch_uat.yml
@@ -19,11 +19,11 @@ jobs:
         run: echo ${{github.ref}}
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -44,9 +44,10 @@ jobs:
         run: echo ${{ inputs.NODE_VERSION }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.NODE_VERSION }}
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/new_test_pr_main.yml
+++ b/.github/workflows/new_test_pr_main.yml
@@ -12,11 +12,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         env:
           cache-name: cache-node-modules
         with:
@@ -37,9 +37,10 @@ jobs:
         run: echo ${{ inputs.NODE_VERSION }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.NODE_VERSION }}
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/release_tag_main.yml
+++ b/.github/workflows/release_tag_main.yml
@@ -19,7 +19,7 @@ jobs:
       AWS_REGION: "us-east-1"
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
         with: { fetch-depth: 0 }
 
       - run: git config user.email "$GITHUB_ACTOR@users.noreply.github.com"


### PR DESCRIPTION
# 🔄 Atualização das GitHub Actions para Compatibilidade Real com Node.js 24

## 📋 Contexto

O GitHub anunciou a **depreciação do Node.js 20** para actions runners, que será substituído por **Node.js 24 a partir de 2 de junho de 2026**. Actions antigas que dependem do Node.js 20 podem parar de funcionar após essa data.

**Referência:** [GitHub Blog - Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

## ⚠️ Por que foi necessário atualizar novamente?

Na primeira iteração (PR #6), as actions foram atualizadas para \`@v4\`, com a expectativa de resolver a depreciação. Entretanto, ao executar os workflows, o seguinte aviso continuou aparecendo:

> \`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-node@v4, softprops/action-gh-release@v1.\`

### Investigação

Verificando diretamente o \`action.yml\` de cada uma das versões \`@v4\`:

| Action | Tag | Runtime declarado |
|--------|-----|-------------------|
| \`actions/checkout@v4\` | \`using: node20\` ❌ |
| \`actions/cache@v4\` | \`using: node20\` ❌ |
| \`actions/setup-node@v4\` | \`using: node20\` ❌ |
| \`softprops/action-gh-release@v1\` | \`using: node16\` ❌ |

**Conclusão:** as versões \`@v4\` ainda rodam em **Node.js 20** (e a \`@v1\` do \`action-gh-release\` em Node.js 16). Para de fato eliminar o aviso de depreciação, é necessário subir para versões que utilizem \`node24\` como runtime.

## 🎯 Objetivo

Atualizar todas as GitHub Actions para versões que efetivamente utilizam **Node.js 24 como runtime**, garantindo continuidade operacional após junho/2026.

## 📝 Alterações Realizadas

### Versões finais

| Action | Versão Anterior | Versão Atual | Runtime |
|--------|----------------|--------------|---------|
| \`actions/checkout\` | \`v4\` | \`v5.0.1\` | \`node24\` ✅ |
| \`actions/cache\` | \`v4\` | \`v5.0.5\` | \`node24\` ✅ |
| \`actions/setup-node\` | \`v4\` | \`v6.4.0\` | \`node24\` ✅ |
| \`softprops/action-gh-release\` | \`v1\` | \`v3.0.0\` | \`node24\` ✅ |

### Decisões conservadoras

#### 1. \`actions/checkout@v5.0.1\` (não \`v6\`)
A versão \`v6\` introduziu uma mudança em \`persist-credentials\`, que passou a armazenar as credenciais em \`\$RUNNER_TEMP\` ao invés de \`.git/config\`. Como nossos workflows fazem \`git push\` em alguns casos (\`new_deploy_branch_prd.yml\`, \`release_tag_main.yml\`), optou-se pela \`v5.0.1\` que já roda em Node.js 24 mas mantém o comportamento histórico de credentials.

#### 2. \`actions/setup-node@v6.4.0\` + \`package-manager-cache: false\`
A partir da \`v5.0.0\`, o \`setup-node\` passou a fazer auto-cache automaticamente quando o campo \`packageManager\` está presente no \`package.json\`. Como nossos workflows já possuem um step explícito de \`actions/cache\`, foi adicionado \`package-manager-cache: false\` para evitar dois mecanismos de cache rodando em paralelo, prevenindo cache duplicado e potencial confusão para projetos consumidores que utilizem o campo \`packageManager\`.

\`\`\`yaml
- name: Setup Node
  uses: actions/setup-node@v6.4.0
  with:
    node-version: \${{ inputs.NODE_VERSION }}
    package-manager-cache: false
\`\`\`

### Arquivos modificados

#### ✅ Workflows atualizados:
- \`.github/workflows/new_deploy_branch_prd.yml\`
- \`.github/workflows/new_deploy_branch_uat.yml\`
- \`.github/workflows/new_deploy_branch_dev.yml\`
- \`.github/workflows/new_test_pr_main.yml\`
- \`.github/workflows/release_tag_main.yml\`

#### ❌ Workflows não alterados:
- \`.github/workflows/workflow.yaml\` (mantido intencionalmente)
- \`.github/workflows/deprecated/*\` (pasta excluída conforme requisito)

## ✅ Garantias

- ✅ Todas as actions agora rodam em **Node.js 24** (verificado diretamente nos \`action.yml\` das tags utilizadas)
- ✅ Versão do Node.js do projeto consumer (\`NODE_VERSION\` input) **não foi alterada**
- ✅ Toda a lógica das pipelines foi **preservada** (steps, env, cache keys, scripts)
- ✅ Workflows continuarão funcionando após 2 de junho de 2026
- ✅ Aviso de depreciação \`Node.js 20 actions are deprecated\` será eliminado

## 🧪 Testes Necessários

- [ ] Validar workflow \`new_deploy_branch_dev.yml\` em branch de desenvolvimento
- [ ] Validar workflow \`new_test_pr_main.yml\` em Pull Request de teste
- [ ] Validar workflow \`new_deploy_branch_uat.yml\` em ambiente UAT
- [ ] Validar workflow \`new_deploy_branch_prd.yml\` em deploy de produção
- [ ] Verificar cache de dependências funcionando corretamente
- [ ] Confirmar upload de coverage para Codecov
- [ ] Confirmar ausência do warning de depreciação Node.js 20

## 📚 Documentação das Versões

- [actions/checkout@v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)
- [actions/cache@v5.0.5](https://github.com/actions/cache/releases/tag/v5.0.5)
- [actions/setup-node@v6.4.0](https://github.com/actions/setup-node/releases/tag/v6.4.0)
- [softprops/action-gh-release@v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0)

## 🔒 Impacto

**Risco:** Baixo
**Tipo:** Manutenção preventiva
**Urgência:** Média (deve ser aplicado antes de junho de 2026)